### PR TITLE
Allow the deploy workflow to be triggered remotely

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types: [redeploy]
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -11,6 +14,9 @@ jobs:
         uses: actions/checkout@v3.2.0
         with:
           submodules: true
+
+      - name: Update submodules
+        run: git submodule update --remote
 
       - name: Install and Build
         run: |

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -12,6 +12,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Update submodules
+        run: git submodule update --remote
+
       - name: Install and Build
         run: |
           npm install


### PR DESCRIPTION
So that the opg-data-lpa-store repo can force a rebuild when the LPA schema changes.

Also ensures that submodules are updated to HEAD

For CTC-149 #minor