### PR TITLE
Trigger rebuilds on schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - main
-  repository_dispatch:
-    types: [redeploy]
+  schedule:
+    - cron: '0 7 * * 1-5'
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Redeploy the site every morning to ensure it has an up-to-date copy of schemas from opg-data-lpa-store.

Also make it manually dispatchable so that we can trigger it if we need an urgent update.

This is an alternative to remote repository dispatches, which would have required personal access tokens.

Fixes CTC-149 #patch